### PR TITLE
added warnings about naive hashing + replaced subscripts with superscripts

### DIFF
--- a/UTxO/DecisionProcedure.agda
+++ b/UTxO/DecisionProcedure.agda
@@ -20,7 +20,6 @@ open import Relation.Binary                       using (Decidable)
 open import Relation.Binary.PropositionalEquality using (_≡_; refl; setoid)
 
 open import UTxO.Hashing.Base
-open import UTxO.Hashing.Types    using (_♯ᵢ)
 open import UTxO.Hashing.MetaHash using (_♯)
 open import UTxO.Types
 
@@ -32,7 +31,7 @@ module UTxO.DecisionProcedure
 
 open import UTxO.Ledger      Address _♯ₐ _≟ₐ_
 open import UTxO.TxUtilities Address _♯ₐ _≟ₐ_
-open import UTxO.Hashing.Tx  Address _♯ₐ _≟ₐ_ using (_♯ₜₓ)
+open import UTxO.Hashing.Tx  Address _♯ₐ _≟ₐ_ using (_♯ᵗˣ)
 open import UTxO.Validity    Address _♯ₐ _≟ₐ_
 
 ∀? : ∀ {ℓ ℓ′} {A : Set ℓ}
@@ -64,13 +63,13 @@ open import UTxO.Validity    Address _♯ₐ _≟ₐ_
                                }
 
 validTxRefs? : ∀ (tx : Tx) (l : Ledger)
-  → Dec (∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+  → Dec (∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
 validTxRefs? tx l =
   ∀? (inputs tx) λ i _ →
-    any (λ t → t ♯ₜₓ ≟ id (outputRef i)) l
+    any (λ t → t ♯ᵗˣ ≟ id (outputRef i)) l
 
 validOutputIndices? : ∀ (tx : Tx) (l : Ledger)
-  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
   → Dec (∀ i → (i∈ : i ∈ inputs tx) →
            index (outputRef i) < length (outputs (lookupTx l (outputRef i) (v₁ i i∈))))
 validOutputIndices? tx l v₁ =
@@ -84,7 +83,7 @@ validOutputRefs? tx l =
     outputRef i SETₒ.∈? SETₒ.list (unspentOutputs l)
 
 preservesValues? : ∀ (tx : Tx) (l : Ledger)
-  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
   → (v₂ : ∀ i → (i∈ : i ∈ inputs tx) →
             index (outputRef i) < length (outputs (lookupTx l (outputRef i) (v₁ i i∈))))
   → Dec (forge tx +ᶜ sumᶜ (mapWith∈ (inputs tx) λ {i} i∈ → lookupValue l i (v₁ i i∈) (v₂ i i∈))
@@ -101,7 +100,7 @@ noDoubleSpending? tx l =
   SETₒ.unique? (map outputRef (inputs tx))
 
 allInputsValidate? : ∀ (tx : Tx) (l : Ledger)
-  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
   → (v₂ : ∀ i → (i∈ : i ∈ inputs tx) →
             index (outputRef i) < length (outputs (lookupTx l (outputRef i) (v₁ i i∈))))
   → Dec (∀ i → (i∈ : i ∈ inputs tx) →
@@ -114,7 +113,7 @@ allInputsValidate? tx l v₁ v₂ =
         ptx = mkPendingTx l tx i i∈ v₁ v₂
     in T? (runValidation ptx i out)
 validateValidHashes? : ∀ (tx : Tx) (l : Ledger)
-  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+  → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
   → (v₂ : ∀ i → (i∈ : i ∈ inputs tx) →
             index (outputRef i) < length (outputs (lookupTx l (outputRef i) (v₁ i i∈))))
   → Dec (∀ i → (i∈ : i ∈ inputs tx) →

--- a/UTxO/ExampleLedger.agda
+++ b/UTxO/ExampleLedger.agda
@@ -60,7 +60,7 @@ forge   t₁ = $ 1000
 fee     t₁ = $0
 
 t₁₀ : TxOutputRef
-t₁₀ = (t₁ ♯ₜₓ) indexed-at 0
+t₁₀ = (t₁ ♯ᵗˣ) indexed-at 0
 
 t₂ : Tx
 inputs  t₂ = [ withScripts t₁₀ ]
@@ -69,10 +69,10 @@ forge   t₂ = $0
 fee     t₂ = $0
 
 t₂₀ : TxOutputRef
-t₂₀ = (t₂ ♯ₜₓ) indexed-at 0
+t₂₀ = (t₂ ♯ᵗˣ) indexed-at 0
 
 t₂₁ : TxOutputRef
-t₂₁ = (t₂ ♯ₜₓ) indexed-at 1
+t₂₁ = (t₂ ♯ᵗˣ) indexed-at 1
 
 t₃ : Tx
 inputs  t₃ = [ withScripts t₂₁ ]
@@ -81,7 +81,7 @@ forge   t₃ = $0
 fee     t₃ = $ 1
 
 t₃₀ : TxOutputRef
-t₃₀ = (t₃ ♯ₜₓ) indexed-at 0
+t₃₀ = (t₃ ♯ᵗˣ) indexed-at 0
 
 t₄ : Tx
 inputs  t₄ = withScripts t₃₀ ∷ []
@@ -90,7 +90,7 @@ forge   t₄ = $ 10
 fee     t₄ = $ 2
 
 t₄₀ : TxOutputRef
-t₄₀ = (t₄ ♯ₜₓ) indexed-at 0
+t₄₀ = (t₄ ♯ᵗˣ) indexed-at 0
 
 t₅ : Tx
 inputs  t₅ = withScripts t₂₀ ∷ withScripts t₄₀ ∷ []
@@ -99,10 +99,10 @@ forge   t₅ = $0
 fee     t₅ = $ 7
 
 t₅₀ : TxOutputRef
-t₅₀ = (t₅ ♯ₜₓ) indexed-at 0
+t₅₀ = (t₅ ♯ᵗˣ) indexed-at 0
 
 t₅₁ : TxOutputRef
-t₅₁ = (t₅ ♯ₜₓ) indexed-at 1
+t₅₁ = (t₅ ♯ᵗˣ) indexed-at 1
 
 t₆ : Tx
 inputs  t₆ = withScripts t₅₀ ∷ withScripts t₅₁ ∷ []
@@ -111,7 +111,7 @@ forge   t₆ = $0
 fee     t₆ = $ 1
 
 t₆₀ : TxOutputRef
-t₆₀ = (t₆ ♯ₜₓ) indexed-at 0
+t₆₀ = (t₆ ♯ᵗˣ) indexed-at 0
 
 -- hash postulates + rewriting
 postulate

--- a/UTxO/Hashing/Base.agda
+++ b/UTxO/Hashing/Base.agda
@@ -39,14 +39,18 @@ _⟨$⟩_ : ∀ {ℓᵃ ℓᵇ} {A : Set ℓᵃ} {B : Set ℓᵇ} {_♯ᵃ : Has
 inj ⟨$⟩ a = a -via- (A↣B inj)
 
 -- Common hashing utilities.
+
+-- NOTE these hash functions can create collisions and are only for
+-- testing/readability of examples
+
 merge♯ : List ℕ → ℕ
 merge♯ = sum
 
-hashList : ∀ {ℓ} {A : Set ℓ} → (A → ℕ) → (List A → ℕ)
+hashList : ∀ {ℓ} {A : Set ℓ} → Hash A → Hash (List A)
 hashList hash1 = merge♯ ∘ map hash1
 
 hashPair : ∀ {ℓ₁ ℓ₂} {A : Set ℓ₁} {B : Set ℓ₂} → Hash A → Hash B → Hash (A × B)
 hashPair h₁ h₂ (a , b) = merge♯ (h₁ a ∷ h₂ b ∷ [])
 
-_♯ₛₜᵣ : String → ℕ
-_♯ₛₜᵣ = hashList toℕ ∘ toList
+_♯ˢᵗʳ : String → ℕ
+_♯ˢᵗʳ = hashList toℕ ∘ toList

--- a/UTxO/Hashing/Tx.agda
+++ b/UTxO/Hashing/Tx.agda
@@ -1,5 +1,8 @@
 ------------------------------------------------------------------------
 -- Naive hashing functions for UTxO types.
+
+-- NOTE these hash functions can create collisions and are only for
+-- testing/readability of examples
 ------------------------------------------------------------------------
 open import Data.List using ([]; _∷_)
 
@@ -12,24 +15,24 @@ open import UTxO.Hashing.Types
 
 module UTxO.Hashing.Tx
   (Address : Set)
-  (_♯ₐ : Hash Address)
-  (_≟ₐ_ : Decidable {A = Address} _≡_)
+  (_♯ᵃ : Hash Address)
+  (_≟ᵃ_ : Decidable {A = Address} _≡_)
   where
 
-open import UTxO.Ledger Address _♯ₐ _≟ₐ_
+open import UTxO.Ledger Address _♯ᵃ _≟ᵃ_
 
-_♯ₒ : Hash TxOutput
-o ♯ₒ = merge♯ ((value o) ♯ᵥ ∷ (address o) ♯ₐ ∷ [])
-postulate injective♯ₒ : Injective _♯ₒ
+_♯ᵒ : Hash TxOutput
+o ♯ᵒ = merge♯ ((value o) ♯ᵛ ∷ (address o) ♯ᵃ ∷ [])
+postulate injective♯ₒ : Injective _♯ᵒ
 
-_♯ₜₓ : Hash Tx
-tx ♯ₜₓ = merge♯ ( (hashList _♯ᵢ) (inputs tx)
-                ∷ (hashList _♯ₒ) (outputs tx)
-                ∷ (forge tx) ♯ᵥ
-                ∷ (fee tx) ♯ᵥ
+_♯ᵗˣ : Hash Tx
+tx ♯ᵗˣ = merge♯ ( (hashList _♯ⁱ) (inputs tx)
+                ∷ (hashList _♯ᵒ) (outputs tx)
+                ∷ (forge tx) ♯ᵛ
+                ∷ (fee tx) ♯ᵛ
                 ∷ []
                 )
-postulate injective♯ₜₓ : Injective _♯ₜₓ
+postulate injective♯ᵗˣ : Injective _♯ᵗˣ
 
-infix 9 _♯ₒ
-infix 9 _♯ₜₓ
+infix 9 _♯ᵒ
+infix 9 _♯ᵗˣ

--- a/UTxO/Hashing/Types.agda
+++ b/UTxO/Hashing/Types.agda
@@ -1,6 +1,10 @@
 ------------------------------------------------------------------------
 -- Naive hashing functions for basic types.
+
+-- NOTE these hash functions can create collisions and are only for
+-- testing/readability of examples
 ------------------------------------------------------------------------
+
 module UTxO.Hashing.Types where
 
 open import Data.Product using (_×_; _,_)
@@ -10,43 +14,38 @@ open import Data.Integer using (ℤ; ∣_∣)
 open import UTxO.Hashing.Base
 open import UTxO.Types
 
-_♯ₛₜ : Hash State
-st ♯ₛₜ = height st
-postulate injective♯ₛₜ : Injective _♯ₛₜ
+_♯ᵒʳ : Hash TxOutputRef
+o ♯ᵒʳ = merge♯ (id o ∷ index o ∷ [])
+postulate injective♯ᵒʳ : Injective _♯ᵒʳ
 
-_♯ₒᵣ : Hash TxOutputRef
-o ♯ₒᵣ = merge♯ (id o ∷ index o ∷ [])
-postulate injective♯ₒᵣ : Injective _♯ₒᵣ
+_♯ⁱ : Hash TxInput
+i ♯ⁱ = (outputRef i) ♯ᵒʳ
+postulate injective♯ⁱ : Injective _♯ⁱ
 
-_♯ᵢ : Hash TxInput
-i ♯ᵢ = (outputRef i) ♯ₒᵣ
-postulate injective♯ᵢ : Injective _♯ᵢ
-
-_♯ᵥ : Hash Value
-_♯ᵥ = λ x → x
-postulate injective♯ᵥ : Injective _♯ᵥ
+_♯ᵛ : Hash Value
+_♯ᵛ = λ x → x
+postulate injective♯ᵥ : Injective _♯ᵛ
 
 _♯ℤ : Hash ℤ
 _♯ℤ = ∣_∣
 
 _♯ᵈ : Hash DATA
 _♯ᵈˢ : Hash (List DATA)
-_♯ᵈˢ′ : Hash (List (DATA × DATA))
+_♯ᵈᵈˢ : Hash (List (DATA × DATA))
 
 I z ♯ᵈ         = z ♯ℤ
 H n ♯ᵈ         = n
 LIST ds ♯ᵈ     = ds ♯ᵈˢ
 CONSTR n ds ♯ᵈ = merge♯ (n ∷ (ds ♯ᵈˢ) ∷ [])
-MAP ds′ ♯ᵈ     = ds′ ♯ᵈˢ′
+MAP ds′ ♯ᵈ     = ds′ ♯ᵈᵈˢ
 
 [] ♯ᵈˢ       = 0
 (d ∷ ds) ♯ᵈˢ = merge♯ ((d ♯ᵈ) ∷ (ds ♯ᵈˢ) ∷ [])
 
-[] ♯ᵈˢ′              = 0
-((d , d′) ∷ ds) ♯ᵈˢ′ = merge♯ ((d ♯ᵈ) ∷ (d′ ♯ᵈ) ∷ (ds ♯ᵈˢ′) ∷ [])
+[] ♯ᵈᵈˢ              = 0
+((d , d′) ∷ ds) ♯ᵈᵈˢ = merge♯ ((d ♯ᵈ) ∷ (d′ ♯ᵈ) ∷ (ds ♯ᵈᵈˢ) ∷ [])
 
-infix 9 _♯ₛₜ
-infix 9 _♯ₒᵣ
-infix 9 _♯ᵢ
-infix 9 _♯ᵥ
+infix 9 _♯ᵒʳ
+infix 9 _♯ⁱ
+infix 9 _♯ᵛ
 infix 9 _♯ᵈ

--- a/UTxO/TxUtilities.agda
+++ b/UTxO/TxUtilities.agda
@@ -24,18 +24,18 @@ open import UTxO.Types
 
 module UTxO.TxUtilities
   (Address : Set)
-  (_♯ₐ : Hash Address)
-  (_≟ₐ_ : Decidable {A = Address} _≡_)
+  (_♯ᵃ : Hash Address)
+  (_≟ᵃ_ : Decidable {A = Address} _≡_)
   where
 
-open import UTxO.Ledger     Address _♯ₐ _≟ₐ_
-open import UTxO.Hashing.Tx Address _♯ₐ _≟ₐ_
+open import UTxO.Ledger     Address _♯ᵃ _≟ᵃ_
+open import UTxO.Hashing.Tx Address _♯ᵃ _≟ᵃ_
 
 module _ where
   open SETₒ
 
   unspentOutputsTx : Tx → Set⟨TxOutputRef⟩
-  unspentOutputsTx tx = fromList (map ((tx ♯ₜₓ) indexed-at_) (indices (outputs tx)))
+  unspentOutputsTx tx = fromList (map ((tx ♯ᵗˣ) indexed-at_) (indices (outputs tx)))
 
   spentOutputsTx : Tx → Set⟨TxOutputRef⟩
   spentOutputsTx tx = fromList (map outputRef (inputs tx))
@@ -47,13 +47,13 @@ module _ where
 
 lookupTx : (l : Ledger)
          → (out : TxOutputRef)
-         → Any (λ tx → tx ♯ₜₓ ≡ id out) l
+         → Any (λ tx → tx ♯ᵗˣ ≡ id out) l
          → Tx
 lookupTx l out ∃tx≡id = proj₁ (find ∃tx≡id)
 
 lookupOutput : (l : Ledger)
              → (out : TxOutputRef)
-             → (∃tx≡id : Any (λ tx → tx ♯ₜₓ ≡ id out) l)
+             → (∃tx≡id : Any (λ tx → tx ♯ᵗˣ ≡ id out) l)
              → index out < length (outputs (lookupTx l out ∃tx≡id))
              → TxOutput
 lookupOutput l out ∃tx≡id index≤len =
@@ -61,7 +61,7 @@ lookupOutput l out ∃tx≡id index≤len =
 
 lookupValue : (l : Ledger)
             → (input : TxInput)
-            → (∃tx≡id : Any (λ tx → tx ♯ₜₓ ≡ id (outputRef input)) l)
+            → (∃tx≡id : Any (λ tx → tx ♯ᵗˣ ≡ id (outputRef input)) l)
             → index (outputRef input) <
                 length (outputs (lookupTx l (outputRef input) ∃tx≡id))
             → Value
@@ -75,13 +75,13 @@ mkPendingTxOut : TxOutput → PendingTxOutput
 mkPendingTxOut txOut =
   record
     { value         = value txOut
-    ; validatorHash = (address txOut) ♯ₐ
+    ; validatorHash = (address txOut) ♯ᵃ
     ; dataHash      = (dataVal txOut) ♯ᵈ
     }
 
 mkPendingTxIn : (l : Ledger)
               → (input : TxInput)
-              → (∃tx≡id : Any (λ tx → tx ♯ₜₓ ≡ id (outputRef input)) l)
+              → (∃tx≡id : Any (λ tx → tx ♯ᵗˣ ≡ id (outputRef input)) l)
               → index (outputRef input) < length (outputs (lookupTx l (outputRef input) ∃tx≡id))
               → PendingTxInput
 mkPendingTxIn l txIn ∃tx index< =
@@ -98,7 +98,7 @@ mkPendingTx : (l : Ledger)
             → (tx : Tx)
             → (i : TxInput)
             → i ∈ inputs tx
-            → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l)
+            → (v₁ : ∀ i → i ∈ inputs tx → Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l)
             → (∀ i → (i∈ : i ∈ inputs tx) →
                  index (outputRef i) < length (outputs (lookupTx l (outputRef i) (v₁ i i∈))))
             → PendingTx
@@ -108,6 +108,6 @@ mkPendingTx l tx i i∈ v₁ v₂ =
      ; thisInput     = mkPendingTxIn l i (v₁ i i∈) (v₂ i i∈)
      ; outputInfo    = map mkPendingTxOut (outputs tx)
      ; dataWitnesses = map (λ o → ((dataVal o) ♯ᵈ) , dataVal o) (outputs tx)
-     ; txHash        = tx ♯ₜₓ
+     ; txHash        = tx ♯ᵗˣ
      ; fee           = fee tx
      ; forge         = forge tx }

--- a/UTxO/Types.agda
+++ b/UTxO/Types.agda
@@ -32,14 +32,6 @@ open import UTxO.Value public
 HashId : Set
 HashId = ℕ
 
-record State : Set where
-  field
-    height : ℕ
-open State public
-
-getState : ∀ {A : Set} → List A → State
-getState l = record { height = length l }
-
 -----------------------------------------
 -- First-order data values.
 

--- a/UTxO/Validity.agda
+++ b/UTxO/Validity.agda
@@ -32,7 +32,7 @@ record IsValidTx (tx : Tx) (l : Ledger) : Set where
 
     validTxRefs :
       ∀ i → i ∈ inputs tx →
-        Any (λ t → t ♯ₜₓ ≡ id (outputRef i)) l
+        Any (λ t → t ♯ᵗˣ ≡ id (outputRef i)) l
 
     validOutputIndices :
       ∀ i → (i∈ : i ∈ inputs tx) →


### PR DESCRIPTION
* on my machine the default fonts don't have so many subscripts so
  lots of characters were showing up as white rectangles. Let's stay
  inside the set of common characters. If superscripts are not common
  either then lets change them.

* removed State, validators nol onger have access to chain height.

* added warnings about naive hashing in relevant files.